### PR TITLE
Simplify computing key image.

### DIFF
--- a/linkable_ring_signature.py
+++ b/linkable_ring_signature.py
@@ -57,7 +57,7 @@ def ring_signature(siging_key, key_idx, M, y, G=SECP256k1.generator, hash_func=h
     s = [0] * n
 
     # STEP 1
-    H = H2(y, hash_func=hash_func)
+    H = functools.reduce(lambda p1, p2: p1 + p2, y)
     Y =  H * siging_key
 
     # STEP 2
@@ -110,7 +110,7 @@ def verify_ring_signature(message, y, c_0, s, Y, G=SECP256k1.generator, hash_fun
     n = len(y)
     c = [c_0] + [0] * (n - 1)
 
-    H = H2(y, hash_func=hash_func)
+    H = functools.reduce(lambda p1, p2: p1 + p2, y)
 
     for i in range(n):
         z_1 = (G * s[i]) + (y[i] * c[i])


### PR DESCRIPTION
Hi Fernando,
I would like to ask why "Link for current signer" is so complicated to calculate? After all, private key security is ensured in multiplying a point on an elliptic curve. Or am i wrong? Please look at my example of simplification. Is it possible that this would be correct? If so, it is possible to get rid of many functions: `H2`, `map_to_curve`, etc. What do you think?